### PR TITLE
Fix to handle booleans

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,11 @@ function filterObjectOnSchema(schema, doc){
 
           }else if(sp.type == 'array'){
             if (doc[key]) results[key] = filterObjectOnSchema(sp, doc[key]);
+          }
+          else if(sp.type == 'boolean'){
+            if(doc[key] != null && typeof doc[key] != 'undefined') results[key] = doc[key];
           }else{
-            if (doc[key] != null) results[key] = doc[key]; 
+            if (doc[key]) results[key] = doc[key]; 
           }
         }
       });


### PR DESCRIPTION
Boolean types weren't being handled properly.  If the value is false, it is not set into the object.  I added a new if statement that checks if the type is boolean and is not null and is not 'undefined'.
