### PR TITLE
do not trim empty objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function filterObjectOnSchema(schema, doc){
             } else {
               if (Object.keys(doc[key]).length > 0){
                 results[key] = doc[key];
-              } 
+              } else {
+                results[key] = {};
+              }
             }
 
           }else if(sp.type == 'array'){


### PR DESCRIPTION
This changes removes the trimming of empty objects.
Instead it just sets a new empty object at that location.

I have a use case where I want to `filter(requestSchema, { method: 'GET', headers: {} })`

And the removal of empty objects is not helpful.
