### PR TITLE
Added support for dependencies and dependentSchemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,11 @@
-module.exports = filterObjectOnSchema;
+module.exports = invokeFilter;
+const resolveSchemaDependencies = require("./resolveDependencies");
+
+function invokeFilter(schema, doc) {
+  const flatSchema = resolveSchemaDependencies(schema, doc);
+  return filterObjectOnSchema(flatSchema, doc)
+}
+
 
 function filterObjectOnSchema(schema, doc) {
 
@@ -7,42 +14,42 @@ function filterObjectOnSchema(schema, doc) {
   //console.log("DOC: ", JSON.stringify(doc, null, 2));
   //console.log("SCH: ", JSON.stringify(schema, null, 2));
 
-  if(schema.type === 'object') {
+  if (schema.type === 'object') {
     results = {}; // holds this levels items
 
     // process properties  -  recursive
-    Object.keys(schema.properties).forEach(function(key) {
-      if(typeof(doc[key]) !== 'undefined') {
-        if(doc[key] === null) {
+    Object.keys(schema.properties).forEach(function (key) {
+      if (typeof (doc[key]) !== 'undefined') {
+        if (doc[key] === null) {
           results[key] = doc[key];
         } else {
           var sp = schema.properties[key];
-          if(sp.type === 'object') {
+          if (sp.type === 'object') {
 
             // check if property-less object (free-form)
-            if(sp.hasOwnProperty('properties')) {
+            if (sp.hasOwnProperty('properties')) {
               results[key] = filterObjectOnSchema(sp, doc[key]);
             } else {
-              if(Object.keys(doc[key]).length > 0) {
+              if (Object.keys(doc[key]).length > 0) {
                 results[key] = doc[key];
               }
             }
-          } else if(sp.type === 'array') {
-            if(doc[key]) results[key] = filterObjectOnSchema(sp, doc[key]);
-          } else if(sp.type === 'boolean' || sp.type === 'number' || sp.type === 'integer' || sp.type === 'string') {
-            if(typeof doc[key] !== 'undefined') results[key] = doc[key];
+          } else if (sp.type === 'array') {
+            if (doc[key]) results[key] = filterObjectOnSchema(sp, doc[key]);
+          } else if (sp.type === 'boolean' || sp.type === 'number' || sp.type === 'integer' || sp.type === 'string') {
+            if (typeof doc[key] !== 'undefined') results[key] = doc[key];
           } else {
-            if(doc[key]) results[key] = doc[key];
+            if (doc[key]) results[key] = doc[key];
           }
         }
       }
     });
 
-  } else if(schema.type === 'array') {
+  } else if (schema.type === 'array') {
     // arrays can hold objects or literals
-    if(schema.items.type === 'object') {
+    if (schema.items.type === 'object') {
       results = [];
-      doc.forEach(function(item) {
+      doc.forEach(function (item) {
         results.push(filterObjectOnSchema(schema.items, item));
       });
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,185 @@
+{
+  "name": "json-schema-filter",
+  "version": "0.1.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "chai": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+      "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+      "dev": true,
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+      "integrity": "sha1-07cqT+SeyUOTU/GsiT28Qw2ZMUA=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0",
+        "supports-color": "~1.2.0"
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
+      "integrity": "sha1-Eu4hUHCGzZjBBY2ewPSsR2t687I=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true
+    }
+  }
+}

--- a/resolveDependencies.js
+++ b/resolveDependencies.js
@@ -1,0 +1,64 @@
+module.exports = resolveSchemaDependencies;
+
+
+function resolveSchemaDependencies(schema, doc) {
+
+  const dependencies = schema.dependentSchemas || schema.dependencies;
+
+  const flatSchema = Object.create(schema);
+
+  if (dependencies) {
+
+    Object.keys(dependencies).forEach(dep => {
+
+      if (dependencies[dep].oneOf) {
+
+        dependencies[dep].oneOf.forEach(subschema => {
+
+          let propertyExists = false;
+
+          if (doc) {
+            const dependencyInObject = doc[dep];
+            const depValue = subschema.properties[dep].enum[0];
+            if (dependencyInObject !== depValue) return;
+            propertyExists = true;
+          }
+
+          Object.keys(subschema.properties).forEach(key => {
+            if (key !== dep) {
+              flatSchema.properties[key] = subschema.properties[key];
+
+              const isRequired = subschema.required && subschema.required.length && subschema.required.includes(key)
+              if (propertyExists && isRequired) {
+                if (!flatSchema.required) flatSchema.required = [];
+                if (flatSchema.required.includes(key)) return;
+                flatSchema.required.push(key);
+              }
+            }
+          })
+        })
+      } else {
+        if (!dependencies[dep].properties) return;
+
+        Object.keys(dependencies[dep].properties).forEach(key => {
+          const isRequired = dependencies[dep].required && dependencies[dep].required.length && dependencies[dep].required.includes(key);
+
+
+          flatSchema.properties[key] = dependencies[dep].properties[key];
+
+          if (isRequired && doc) {
+            const dependencyInObject = doc[dep];
+            if (dependencyInObject === undefined) return;
+
+            if (!flatSchema.required) flatSchema.required = [];
+            if (flatSchema.required.includes(key)) return;
+            flatSchema.required.push(key);
+          }
+        })
+      }
+    })
+
+  };
+
+  return flatSchema;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,9 @@
 var expect = require('chai').expect;
 var filter = require('../index.js');
+var resolveSchemaDependencies = require("../resolveDependencies");
 
 
-describe('json-schema-filter', function() {
+describe('json-schema-filter', function () {
   var schema = {
     "title": "Example Schema",
     "type": "object",
@@ -42,7 +43,7 @@ describe('json-schema-filter', function() {
           }
         }
       },
-      "hobbies":{
+      "hobbies": {
         "type": "array",
         "required": false,
         "items": {
@@ -54,7 +55,7 @@ describe('json-schema-filter', function() {
   };
 
 
-  it('filters the docuemnt with no exclusions', function() {
+  it('filters the docuemnt with no exclusions', function () {
 
     var document = {
       firstName: 'Andrew',
@@ -66,7 +67,7 @@ describe('json-schema-filter', function() {
     expect(result).to.eql(document);
   });
 
-  it('excludes non schema defined objects', function() {
+  it('excludes non schema defined objects', function () {
     var document = {
       firstName: 'Andrew',
       lastName: 'Lank',
@@ -77,25 +78,25 @@ describe('json-schema-filter', function() {
 
     var result = filter(schema, document);
 
-    expect(result).to.eql({firstName: 'Andrew', lastName: 'Lank', age: 0, isLive: false});
+    expect(result).to.eql({ firstName: 'Andrew', lastName: 'Lank', age: 0, isLive: false });
   });
 
-  it('excludes non schema defined array objects', function() {
+  it('excludes non schema defined array objects', function () {
     var document = {
       firstName: 'Andrew',
-      contacts: [{phone: '5146666666'}, {phone: '5148888888', shouldNot: 'see this'}]
+      contacts: [{ phone: '5146666666' }, { phone: '5148888888', shouldNot: 'see this' }]
     };
 
     var result = filter(schema, document);
 
-    expect(result).to.eql({firstName: 'Andrew', contacts: [{phone: '5146666666'}, {phone: '5148888888'}]});
+    expect(result).to.eql({ firstName: 'Andrew', contacts: [{ phone: '5146666666' }, { phone: '5148888888' }] });
   });
 
-  it('accepts free form objects', function() {
+  it('accepts free form objects', function () {
     var document = {
       firstName: 'Andrew',
-      contacts: [{phone: '5146666666'}, {phone: '5148888888'}],
-      general: {hobbies: ['cylcing', 'jogging', 'death'], drinking_abilities: 'professional'}
+      contacts: [{ phone: '5146666666' }, { phone: '5148888888' }],
+      general: { hobbies: ['cylcing', 'jogging', 'death'], drinking_abilities: 'professional' }
     };
 
     var result = filter(schema, document);
@@ -103,22 +104,22 @@ describe('json-schema-filter', function() {
     expect(result).to.eql(document);
   });
 
-  it('accepts free form objects, if empty do not include them', function() {
+  it('accepts free form objects, if empty do not include them', function () {
     var document = {
       firstName: 'Andrew',
-      contacts: [{phone: '5146666666'}, {phone: '5148888888'}],
+      contacts: [{ phone: '5146666666' }, { phone: '5148888888' }],
       general: {}
     };
 
     var result = filter(schema, document);
 
-    expect(result).to.eql({firstName: 'Andrew', contacts: [{phone: '5146666666'}, {phone: '5148888888'}]});
+    expect(result).to.eql({ firstName: 'Andrew', contacts: [{ phone: '5146666666' }, { phone: '5148888888' }] });
   });
 
-  it('accepts free form objects that are absent', function() {
+  it('accepts free form objects that are absent', function () {
     var document = {
       firstName: 'Andrew',
-      contacts: [{phone: '5146666666'}, {phone: '5148888888'}]
+      contacts: [{ phone: '5146666666' }, { phone: '5148888888' }]
     };
 
     var result = filter(schema, document);
@@ -126,10 +127,10 @@ describe('json-schema-filter', function() {
     expect(result).to.eql(document);
   });
 
-  it('filters array literals', function() {
+  it('filters array literals', function () {
     var document = {
       firstName: 'Andrew',
-      contacts: [{phone: '5146666666'}, {phone: '5148888888'}],
+      contacts: [{ phone: '5146666666' }, { phone: '5148888888' }],
       hobbies: ['driving', 'working', 'working harder', 'wish I wasn\'t working']
     };
 
@@ -138,7 +139,7 @@ describe('json-schema-filter', function() {
     expect(results).to.eql(document);
   });
 
-  it("should not remove empty string property", function() {
+  it("should not remove empty string property", function () {
     var schemaForEmptyStringTest = {
       "type": "object",
       "properties": {
@@ -153,7 +154,7 @@ describe('json-schema-filter', function() {
         }
       }
     };
-    
+
     var data = {
       firstName: 'John',
       lastName: 'Dodd',
@@ -165,9 +166,9 @@ describe('json-schema-filter', function() {
     expect(results).to.eql(data);
   });
 
-  describe("should not omit null for:", function() {
+  describe("should not omit null for:", function () {
     var schemaForNullTest;
-    beforeEach(function() {
+    beforeEach(function () {
       schemaForNullTest = {
         "type": "object",
         "properties": {
@@ -197,8 +198,8 @@ describe('json-schema-filter', function() {
         }
       }
     });
-    
-    it('object', function() {
+
+    it('object', function () {
       var data = {
         firstName: 'John',
         lastName: 'Dodd',
@@ -211,7 +212,7 @@ describe('json-schema-filter', function() {
       expect(results).to.eql(data);
     });
 
-    it('array', function() {
+    it('array', function () {
       var data = {
         firstName: 'John',
         lastName: 'Dodd',
@@ -226,7 +227,7 @@ describe('json-schema-filter', function() {
       expect(results).to.eql(data);
     });
 
-    it('literals', function() {
+    it('literals', function () {
       var data = {
         firstName: null,
         lastName: 'Dodd',
@@ -240,5 +241,109 @@ describe('json-schema-filter', function() {
       var results = filter(schemaForNullTest, data);
       expect(results).to.eql(data);
     });
+  });
+});
+
+describe("The resolveSchemaDependencies function", () => {
+
+  it("should return a flat schema with 3 properties", () => {
+    const schema = {
+      "type": "object",
+
+      "properties": {
+        "name": { "type": "string" },
+        "credit_card": { "type": "number" }
+      },
+
+      "required": ["name"],
+
+      "dependencies": {
+        "credit_card": {
+          "properties": {
+            "billing_address": { "type": "string" }
+          },
+          "required": ["billing_address"]
+        }
+      }
+    };
+
+    const object = {
+      "name": "John Doe",
+      "credit_card": 5555555555555555,
+      "billing_address": "555 Debtor's Lane"
+    };
+
+    const flatSchema = resolveSchemaDependencies(schema, object);
+
+    expect(Object.keys(flatSchema.properties).length).to.equal(3);
+    expect(flatSchema.properties).to.have.keys([
+      "name",
+      "credit_card",
+      "billing_address"
+    ]);
+    console.log("the required props", flatSchema);
+    expect(flatSchema.required[1]).to.equal("billing_address");
+  });
+
+  it("billing_address shouldn't be required if no credit_card is set", () => {
+    const schema = {
+      "type": "object",
+
+      "properties": {
+        "name": { "type": "string" },
+        "credit_card": { "type": "number" }
+      },
+
+      "required": ["name"],
+
+      "dependencies": {
+        "credit_card": {
+          "properties": {
+            "billing_address": { "type": "string" }
+          },
+          "required": ["billing_address"]
+        }
+      }
+    };
+
+    const object = {
+      "name": "John Doe",
+      "billing_address": "555 Debtor's Lane"
+    };
+
+    const flatSchema = resolveSchemaDependencies(schema, object);
+
+    expect(Object.keys(flatSchema.properties).length).to.equal(3);
+    expect(flatSchema.properties).to.have.keys([
+      "name",
+      "credit_card",
+      "billing_address"
+    ]);
+    expect(flatSchema.required).to.have.lengthOf(1);
+    expect(flatSchema.required[0]).to.equal("name");
+  });
+
+  it("shouldn't alter the number of properties for dependencies property in format of dependentRequired", () => {
+
+    const schema = {
+      "type": "object",
+
+      "properties": {
+        "name": { "type": "string" },
+        "credit_card": { "type": "number" },
+        "billing_address": { "type": "string" }
+      },
+
+      "required": ["name"],
+
+      "dependencies": {
+        "credit_card": ["billing_address"]
+      }
+    };
+
+    const flatSchema = resolveSchemaDependencies(schema);
+
+    expect(Object.keys(flatSchema.properties).length).to.equal(3);
+
   });
 });


### PR DESCRIPTION
This commit adds support to dependencies and the latest draft (4-7) dependentSchemas.

Problem it's solving:
When dependencies(or dependentSchemas) add subschemas dynamically, those properties should be valid but will be ignored by the filter. 
The resolveSchemaDependencies function would read the document and flatten the schema based on the dependencies/dependentSchemas property. 
It does nothing with dependentRequired since this property wouldn't inject subschemas.
The resolveSchemaDependencies will also flatten the required array if it exists, since the filter could be used before a validation.

It is tested based on the examples in https://json-schema.org/understanding-json-schema/reference/conditionals.html